### PR TITLE
incorrect api call

### DIFF
--- a/src/action_server/actions/inspect.py
+++ b/src/action_server/actions/inspect.py
@@ -41,7 +41,7 @@ class Inspect(Action):
         self._fsm = robot_smach_states.world_model.Inspect(self._robot,
                                                            entityDes=robot_smach_states.util.designators.EdEntityDesignator(
                                                                self._robot, id=entity.id),
-                                                           inspection_area=area)
+                                                           navigation_area=area)
 
         self._thread = threading.Thread(name='inspect', target=self._fsm.execute)
         self._thread.start()


### PR DESCRIPTION
```
    def __init__(self, robot, entityDes, objectIDsDes=None, searchArea="on_top_of", navigation_area=""):
        """ Constructor

        :param robot: robot object
        :param entityDes: EdEntityDesignator indicating the (furniture) object to inspect
        :param objectIDsDes: designator that is used to store the segmented objects
        :param searchArea: string defining where the objects are w.r.t. the entity, default = on_top_of
        :param navigation_area: string identifying the inspection area. If provided, NavigateToSymbolic is used.
        If left empty, NavigateToObserve is used.
        """
```