### PR TITLE
fix(server, client): use result for log messages

### DIFF
--- a/action/Task.action
+++ b/action/Task.action
@@ -19,9 +19,9 @@ uint8 RESULT_SUCCEEDED=2
 uint8 RESULT_UNKNOWN=3
 
 uint8 result  # Result code as defined in the enum above
----
-# Feedback
 
 # Messages to report to the user about the task planning/
 # execution are returned as feedback in a list of log messages
 string[] log_messages
+---
+# Feedback

--- a/src/action_server/client.py
+++ b/src/action_server/client.py
@@ -47,12 +47,6 @@ class Client(object):
 
         self.get_actions_proxy = rospy.ServiceProxy('get_actions', action_server.srv.GetActions)
 
-        self._feedback = []
-
-    def _handle_feedback(self, feedback):
-        for message in feedback.log_messages:
-            self._feedback.append(message)
-
 
     def get_actions(self):
         """
@@ -78,14 +72,13 @@ class Client(object):
         and depending on the type of action, several parameter fields may be required.
         :return: True or false, and a message specifying the outcome of the task
         """
-        self._feedback = []
 
         recipe = semantics
 
         result = None
         while not result:
             goal = action_server.msg.TaskGoal(recipe=recipe)
-            self._action_client.send_goal(goal, feedback_cb=self._handle_feedback)
+            self._action_client.send_goal(goal)
             self._action_client.wait_for_result()
             result = self._action_client.get_result()
 

--- a/src/action_server/client.py
+++ b/src/action_server/client.py
@@ -91,20 +91,20 @@ class Client(object):
 
         if result.result == action_server.msg.TaskResult.RESULT_MISSING_INFORMATION:
             to = TaskOutcome(TaskOutcome.RESULT_MISSING_INFORMATION,
-                             self._feedback)
+                             result.log_messages)
             to.missing_field = result.missing_field
             return to
 
         elif result.result == action_server.msg.TaskResult.RESULT_TASK_EXECUTION_FAILED:
             return TaskOutcome(TaskOutcome.RESULT_TASK_EXECUTION_FAILED,
-                               self._feedback)
+                               result.log_messages)
 
         elif result.result == action_server.msg.TaskResult.RESULT_UNKNOWN:
             return TaskOutcome(TaskOutcome.RESULT_UNKNOWN,
-                               self._feedback)
+                               result.log_messages)
 
         elif result.result == action_server.msg.TaskResult.RESULT_SUCCEEDED:
             return TaskOutcome(TaskOutcome.RESULT_SUCCEEDED,
-                               self._feedback)
+                               result.log_messages)
 
-        return TaskOutcome(messages=self._feedback)
+        return TaskOutcome(messages=result.log_messages)


### PR DESCRIPTION
The log message is no longer sent using feedback because sending the
feedback is always done just before canceling or succeeding the goal.
As the feedback is handled in a separate thread, it is not guaranteed to
be handled before the goal is canceled/succeeded.