### PR TITLE
Feature/subtask feedback

### DIFF
--- a/action_server/src/action_server/actions/action.py
+++ b/action_server/src/action_server/actions/action.py
@@ -85,7 +85,7 @@ class Action(object):
 
     def configure(self, robot, config):
         rospy.loginfo("Configuring action {} with semantics {} and knowledge {}.".
-                       format(self.__class__.__name__, config.semantics, config.knowledge))
+                       format(self.get_name(), config.semantics, config.knowledge))
         if not isinstance(config, ConfigurationData):
             rospy.logerr("Action: the specified config should be ConfigurationData! I received: %s" % str(config))
             self._config_result.message = " Something's wrong with my wiring. I'm so sorry, but I cannot do this. "
@@ -107,7 +107,7 @@ class Action(object):
         raise NotImplementedError
 
     def start(self):
-        rospy.loginfo("Starting executing of action {}.".format(self.__class__.__name__))
+        rospy.loginfo("Starting executing of action {}.".format(self.get_name()))
         self._start()
         return self._execute_result
 
@@ -115,8 +115,11 @@ class Action(object):
         raise NotImplementedError
 
     def cancel(self):
-        rospy.loginfo("Canceling executing of action {}.".format(self.__class__.__name__))
+        rospy.loginfo("Canceling executing of action {}.".format(self.get_name()))
         return self._cancel()
 
     def _cancel(self):
         raise NotImplementedError
+
+    def get_name(self):
+        return self.__class__.__name__

--- a/action_server/src/action_server/server.py
+++ b/action_server/src/action_server/server.py
@@ -18,7 +18,7 @@ class Server(object):
         self._action_name = "/" + self._robot.robot_name + "/action_server/task"
         self._action_server = actionlib.SimpleActionServer(self._action_name, action_server_msgs.msg.TaskAction,
                                                            execute_cb=self._add_action_cb, auto_start=False)
-        
+
         self._action_server.register_preempt_callback(cb=self._cancel)
         self._result = action_server_msgs.msg.TaskResult()
 
@@ -63,6 +63,11 @@ class Server(object):
             return
 
         while not self._task_manager.done:
+            # Pass feedback to client about what type of action is running
+            feedback = action_server_msgs.msg.TaskFeedback()
+            feedback.current_subtask = self._task_manager.get_next_action_name()
+            self._action_server.publish_feedback(feedback)
+
             action_result = self._task_manager.execute_next_action()
             rospy.logdebug("Result of action execution: {}".format(action_result))
             self._result.log_messages.append(action_result.message)

--- a/action_server/src/action_server/task_manager.py
+++ b/action_server/src/action_server/task_manager.py
@@ -58,6 +58,12 @@ class TaskManager(object):
 
         return configuration_result
 
+    def get_next_action_name(self):
+        if self._action_sequence:
+            return self._action_sequence[0].get_name()
+        else:
+            return None
+
     def execute_next_action(self):
         self._active_action = self._action_sequence.pop(0)
         result = self._active_action.start()

--- a/action_server_msgs/action/Task.action
+++ b/action_server_msgs/action/Task.action
@@ -25,3 +25,4 @@ uint8 result  # Result code as defined in the enum above
 string[] log_messages
 ---
 # Feedback
+string current_subtask


### PR DESCRIPTION
I added the field `current_subtask` to the (so far empty) feedback message definition. This tells you what kind of action is currently running. I named it 'subtask' and not 'action' because I want to move to a different naming of our 'actions' and 'action server' to avoid confusion with actionlib's action server.