### PR TITLE
added try-except statements to handle crashing of actions

### DIFF
--- a/action_server/src/action_server/server.py
+++ b/action_server/src/action_server/server.py
@@ -43,9 +43,10 @@ class Server(object):
         if isinstance(recipe, dict) and 'actions' in recipe and recipe['actions']:
             configuration_result = self._task_manager.set_up_state_machine(recipe['actions'])
         else:
-            rospy.logerr('Recipe does not contain actions, setting configuration result to failed')
+            rospy.logerr("Recipe does not contain actions, setting configuration result to failed")
             configuration_result = ConfigurationResult()
             configuration_result.succeeded = False
+            configuration_result.message = "I do not understand your command."
         rospy.logdebug("Result of state machine setup: {}".format(configuration_result))
 
         self._result.log_messages = []
@@ -59,8 +60,7 @@ class Server(object):
                 self._result.log_messages.append(" I don't have enough information to perform that task.")
                 self._result.log_messages.append(configuration_result.message)
             elif configuration_result.message:
-                # TODO: this task result should not be RESULT_UNKNOWN
-                self._result.result = action_server_msgs.msg.TaskResult.RESULT_UNKNOWN
+                self._result.result = action_server_msgs.msg.TaskResult.RESULT_TASK_CONFIGURATION_FAILED
                 self._result.log_messages.append(configuration_result.message)
             else:
                 self._result.result = action_server_msgs.msg.TaskResult.RESULT_UNKNOWN

--- a/action_server_msgs/action/Task.action
+++ b/action_server_msgs/action/Task.action
@@ -14,9 +14,10 @@ string recipe
 string missing_field
 
 uint8 RESULT_MISSING_INFORMATION=0
-uint8 RESULT_TASK_EXECUTION_FAILED=1
-uint8 RESULT_SUCCEEDED=2
-uint8 RESULT_UNKNOWN=3
+uint8 RESULT_TASK_CONFIGURATION_FAILED=1
+uint8 RESULT_TASK_EXECUTION_FAILED=2
+uint8 RESULT_SUCCEEDED=3
+uint8 RESULT_UNKNOWN=4
 
 uint8 result  # Result code as defined in the enum above
 


### PR DESCRIPTION
When running amigo-challenge-gpsr

If request are given:

amigo-hear find the person near the cabinet and answer a question
<crashes, but 'answer a question' remains in the action sequence>

amigo-hear amigo-hear go to the hallway
<'answer a question' will be executed>

therefore, added try-except statements that force preempting the action sequence first

Some discussion is needed what kind of behaviour we want.
Added questions inline.

Other error output that is solved in server.py:

[INFO] [1511901820.541596]: 'I heard accompany jane from the bed to the cabinet, is this correct?'
--
[INFO] [1511901825.870840]: Question: , grammar: T -> yes \| no
[INFO] [1511901825.871243]: Example: 'yes'
[INFO] [1511901827.841359]: Robot heard 'yes' None
[ERROR] [1511901827.844337]: Exception in your execute callback: 'bool' object has no attribute '__getitem__'
Traceback (most recent call last):
File "/opt/ros/kinetic/lib/python2.7/dist-packages/actionlib/simple_action_server.py", line 289, in executeLoop
self.execute_callback(goal)
File "/home/amigo/ros/kinetic/repos/https_/github.com/tue-robotics/action_server.git/action_server/src/action_server/server.py", line 39, in _add_action_cb
configuration_result = self._task_manager.set_up_state_machine(recipe['actions'])
TypeError: 'bool' object has no attribute '__getitem__'




